### PR TITLE
Why we have weird FileSizes?

### DIFF
--- a/src/Gml.Core/Core/Helpers/Game/GameDownloaderProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Game/GameDownloaderProcedures.cs
@@ -202,7 +202,7 @@ namespace Gml.Core.Helpers.Game
                     Name = Path.GetFileName(c),
                     Directory = path,
                     FullPath = c,
-                    Size = c.Length,
+                    Size = new FileInfo(c).Length,
                     Hash = hash
                 });
             }));


### PR DESCRIPTION
Looks like we are getting length of path, instead of file

If that inteded to be like that, let's make another variable with FileSize, it can be useful.