### PR TITLE
Enhance profile lookup with case-insensitive comparison

### DIFF
--- a/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -235,7 +235,7 @@ namespace Gml.Core.Helpers.Profiles
         {
             await RestoreProfiles();
 
-            var profile = _gameProfiles.FirstOrDefault(c => c.Name == profileName);
+            var profile = _gameProfiles.FirstOrDefault(c => c.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
 
             return profile;
         }


### PR DESCRIPTION
Previously, profile names were matched using case-sensitive comparison. This update changes the comparison to be case-insensitive, ensuring that profile lookups are more user-friendly and reliable.