### PR TITLE
Add notifications clearing endpoint

### DIFF
--- a/src/Gml.Core.Interfaces/Procedures/INotificationProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/INotificationProcedures.cs
@@ -15,4 +15,5 @@ public interface INotificationProcedures
     Task SendMessage(string message, NotificationType type);
     Task SendMessage(string message, Exception exception);
     Task Retore();
+    Task Clear();
 }

--- a/src/Gml.Core/Core/Helpers/Notifications/NotificationProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Notifications/NotificationProcedures.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using Gml.Core.Constants;
@@ -28,7 +29,7 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
@@ -45,7 +46,7 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
@@ -61,7 +62,7 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
@@ -78,13 +79,19 @@ public class NotificationProcedures(IStorageService storage) : INotificationProc
 
         _notificationsHistory.Add(notification);
 
-        await storage.SetAsync(StorageConstants.Settings, _notificationsHistory);
+        await storage.SetAsync(StorageConstants.Notifications, _notificationsHistory);
 
         _notifications.OnNext(notification);
     }
 
     public async Task Retore()
     {
-        _notificationsHistory = await storage.GetAsync<List<Notification>>(StorageConstants.Settings) ?? [];
+        _notificationsHistory = await storage.GetAsync<List<Notification>>(StorageConstants.Notifications) ?? [];
+    }
+
+    public async Task Clear()
+    {
+        _notificationsHistory.Clear();
+        await storage.SetAsync(StorageConstants.Notifications, Enumerable.Empty<Notification>());
     }
 }


### PR DESCRIPTION
Introduce an endpoint for deleting all notifications and align associated storage constants. Updated `INotificationProcedures` and `NotificationProcedures` to support clearing notifications.