### PR TITLE
Update MirrorsHelper URLs and add MirrorsPingModel

### DIFF
--- a/src/Gml.Core/Core/Helpers/Mirrors/MirrorsHelper.cs
+++ b/src/Gml.Core/Core/Helpers/Mirrors/MirrorsHelper.cs
@@ -11,7 +11,8 @@ public class MirrorsHelper
                 "https://mirror.recloud.tech/openjdk-22_linux-x64_bin.zip",
                 "https://mirror.recloud.host/openjdk-22_linux-x64_bin.zip",
                 "https://mr-1.recloud.tech/openjdk-22_linux-x64_bin.zip",
-                "http://localhost/openjdk-22_linux-x64_bin.zip",
+                "https://mr-2.recloud.tech/openjdk-22_linux-x64_bin.zip",
+                "https://mr-3.recloud.tech/openjdk-22_linux-x64_bin.zip",
             ]
         },
         {
@@ -19,7 +20,8 @@ public class MirrorsHelper
                 "https://mirror.recloud.tech/openjdk-22_windows-x64_bin.zip",
                 "https://mirror.recloud.host/openjdk-22_windows-x64_bin.zip",
                 "https://mr-1.recloud.tech/openjdk-22_windows-x64_bin.zip",
-                "http://localhost/openjdk-22_windows-x64_bin.zip",
+                "https://mr-2.recloud.tech/openjdk-22_windows-x64_bin.zip",
+                "https://mr-3.recloud.tech/openjdk-22_windows-x64_bin.zip",
             ]
         },
     };
@@ -31,7 +33,8 @@ public class MirrorsHelper
                 "https://mirror.recloud.tech/dotnet-sdk-8.0.302-linux-x64.zip",
                 "https://mirror.recloud.host/dotnet-sdk-8.0.302-linux-x64.zip",
                 "https://mr-1.recloud.tech/dotnet-sdk-8.0.302-linux-x64.zip",
-                "http://localhost/dotnet-sdk-8.0.302-linux-x64.zip",
+                "https://mr-2.recloud.tech/dotnet-sdk-8.0.302-linux-x64.zip",
+                "https://mr-3.recloud.tech/dotnet-sdk-8.0.302-linux-x64.zip",
             ]
         },
         {
@@ -39,7 +42,8 @@ public class MirrorsHelper
                 "https://mirror.recloud.tech/dotnet-sdk-8.0.302-win-x64.zip",
                 "https://mirror.recloud.host/dotnet-sdk-8.0.302-win-x64.zip",
                 "https://mr-1.recloud.tech/dotnet-sdk-8.0.302-win-x64.zip",
-                "http://localhost/dotnet-sdk-8.0.302-win-x64.zip",
+                "https://mr-2.recloud.tech/dotnet-sdk-8.0.302-win-x64.zip",
+                "https://mr-3.recloud.tech/dotnet-sdk-8.0.302-win-x64.zip",
             ]
         },
     };

--- a/src/Gml.Core/Core/Helpers/Mirrors/MirrorsPingModel.cs
+++ b/src/Gml.Core/Core/Helpers/Mirrors/MirrorsPingModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Gml.Core.Helpers.Mirrors;
+
+public class MirrorsPingModel
+{
+    public string Url { get; set; }
+    public long RoundtripTime { get; set; }
+}

--- a/src/Gml.Core/Core/Helpers/System/SystemProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/System/SystemProcedures.cs
@@ -5,7 +5,9 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CmlLib.Core.Files;
@@ -144,7 +146,8 @@ namespace Gml.Core.Helpers.System
 
         public async Task DownloadFileAsync(string url, string destinationFilePath)
         {
-            using HttpResponseMessage response = await gmlSettings.HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+            using HttpResponseMessage response =
+                await gmlSettings.HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
             await using Stream contentStream = await response.Content.ReadAsStreamAsync(),
                 fileStream = new FileStream(destinationFilePath, FileMode.Create, FileAccess.Write, FileShare.None,
@@ -163,6 +166,7 @@ namespace Gml.Core.Helpers.System
             {
                 Directory.Delete(extractPath, true);
             }
+
             ZipFile.ExtractToDirectory(zipFilePath, extractPath);
             File.Delete(zipFilePath);
         }
@@ -171,15 +175,41 @@ namespace Gml.Core.Helpers.System
         {
             if (mirrorUrls.TryGetValue(SystemService.GetPlatform(), out string[] mirrors))
             {
+                List<MirrorsPingModel?> mirrorsPing = [];
+
                 foreach (string url in mirrors)
                 {
                     try
                     {
-                        HttpResponseMessage response = await gmlSettings.HttpClient.GetAsync(url);
-                        if (response.IsSuccessStatusCode)
-                        {
-                            return url;
-                        }
+                        Ping mirrorPing = new Ping();
+
+                        Uri uri = new Uri(url);
+                        string domain = uri.Host;
+
+                        var ping = await mirrorPing.SendPingAsync(domain);
+
+                        mirrorPing.Dispose();
+
+                        mirrorsPing.Add(new MirrorsPingModel { Url = url, RoundtripTime = ping.RoundtripTime });
+                    }
+                    catch (Exception)
+                    {
+                        // Ignore the exception and try the next URL
+                    }
+                }
+
+                mirrorsPing = mirrorsPing.OrderBy(x => x.RoundtripTime).ToList();
+
+                foreach (var pingModel in mirrorsPing)
+                {
+                    try
+                    {
+                        HttpResponseMessage response =
+                            await gmlSettings.HttpClient.GetAsync(pingModel.Url,
+                                HttpCompletionOption.ResponseHeadersRead);
+
+                        if (response.StatusCode is HttpStatusCode.OK)
+                            return pingModel.Url;
                     }
                     catch (HttpRequestException)
                     {
@@ -192,7 +222,7 @@ namespace Gml.Core.Helpers.System
                 }
             }
 
-            return null;
+            throw new Exception("Нет доступных зеркал для загрузки файлов");
         }
     }
 }

--- a/src/Gml.Core/Core/Helpers/System/SystemProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/System/SystemProcedures.cs
@@ -16,6 +16,7 @@ using Gml.Core.Helpers.Mirrors;
 using Gml.Core.Launcher;
 using Gml.Core.Services.System;
 using Gml.Models.Bootstrap;
+using Gml.Models.Mirror;
 using GmlCore.Interfaces.Bootstrap;
 using GmlCore.Interfaces.Launcher;
 using GmlCore.Interfaces.Procedures;
@@ -175,7 +176,7 @@ namespace Gml.Core.Helpers.System
         {
             if (mirrorUrls.TryGetValue(SystemService.GetPlatform(), out string[] mirrors))
             {
-                List<MirrorsPingModel?> mirrorsPing = [];
+                List<MirrorPingModel?> mirrorsPing = [];
 
                 foreach (string url in mirrors)
                 {
@@ -190,7 +191,7 @@ namespace Gml.Core.Helpers.System
 
                         mirrorPing.Dispose();
 
-                        mirrorsPing.Add(new MirrorsPingModel { Url = url, RoundtripTime = ping.RoundtripTime });
+                        mirrorsPing.Add(new MirrorPingModel { Url = url, RoundtripTime = ping.RoundtripTime });
                     }
                     catch (Exception)
                     {

--- a/src/Gml.Core/Models/Mirror/MirrorPingModel.cs
+++ b/src/Gml.Core/Models/Mirror/MirrorPingModel.cs
@@ -1,6 +1,6 @@
-﻿namespace Gml.Core.Helpers.Mirrors;
+﻿namespace Gml.Models.Mirror;
 
-public class MirrorsPingModel
+public class MirrorPingModel
 {
     public string Url { get; set; }
     public long RoundtripTime { get; set; }


### PR DESCRIPTION
Replaced localhost URLs with new mirrors for more reliable sources. Introduced MirrorsPingModel class to track URL and round-trip time. Enhanced GetMirrorUrlAsync to select the fastest mirror based on ping results for improved performance.