### PR TITLE
Fix Java runtime folder retrieval by resolving correct OS directory

### DIFF
--- a/src/Gml.Core/Core/Helpers/Game/GameDownloaderProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Game/GameDownloaderProcedures.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using CmlLib.Core;
+using CmlLib.Core.Java;
+using CmlLib.Core.Rules;
 using Gml.Common;
 using Gml.Core.Launcher;
 using Gml.Core.Services.Storage;
@@ -207,9 +209,17 @@ namespace Gml.Core.Helpers.Game
         private static bool GetJavaRuntimeFolder(string osName, string osArchitecture, MinecraftLauncher launcher,
             out string runtimeFolder)
         {
+            var osRule = new LauncherOSRule
+            {
+                Name = osName,
+                Arch = osArchitecture
+            };
+
+            var osDirectory = MinecraftJavaManifestResolver.GetOSNameForJava(osRule);
+
             runtimeFolder = Directory
                 .GetDirectories(
-                    launcher.MinecraftPath.Runtime, $"{osName}??{osArchitecture}", SearchOption.AllDirectories)
+                    launcher.MinecraftPath.Runtime, osDirectory, SearchOption.AllDirectories)
                 .FirstOrDefault() ?? string.Empty;
 
             if (string.IsNullOrEmpty(runtimeFolder) && osName == "linux")


### PR DESCRIPTION
Во время скачивания Java сборок под ОС формируется примерно такой список сборок внутри runtime:

- linux
- linux-i386
- mac-os
- mac-os-arm64
- windows-arm64
- windows-x64
- windows-x86

Наличие этих папок валидируется методом [GetOSNameForJava в CmlLib](https://github.com/CmlLib/CmlLib.Core/blob/d654e8ec180270a66388a8b372d8594f1af20c25/src/Java/MinecraftJavaManifestResolver.cs#L10).

Лаунчер, при запуске под macOS, передаёт в запросе к profiles/info параметр OsType: 2.
"2" маппиться в "osx". 

В методе GetJavaRuntimeFolder, который проверяет наличие папки со сборкой Java под запрашиваемую систему сейчас была написана такая логика поиска папки: "(osName)??(osArch)".
Это не работало верно, потому что:
- Сборка Java для мака скачивалась в `mac-os` и `mac-os-arm64`. Бекенд искал папки `osx` или `osx-64`
- Паттерн поиска с двумя любыми символами по идее работал только с папами для Windows, у которых есть "x", для `mac-os`, `mac-os-arm64`, `windows-arm64` это не должно было работать, ибо там только один неопределенный символ при поиске по шаблону (это разделяющий osName и Arch дефис).

Соответственно, папка с Java не считается найденной, сразу срабатывает первый же return []; и мы получаем пустой список файлов на загрузку.

Я бы предложил использовать тот же самый метод GetOSNameForJava для определения нужной папки со сборкой Java, так как в ней заранее уже есть маппинг всех актуальных сборок и default case с примерно тем же паттерном поиска папки `os + "-" + arch` на случай появления новых сборок.

Предложенное решение успешно проверил под macos/arm64 и windows/64