### PR TITLE
Refactor CustomNewsProvider and add OAuth2 project support

### DIFF
--- a/src/Gml.Core.Interfaces/Integrations/INewsListenerProvider.cs
+++ b/src/Gml.Core.Interfaces/Integrations/INewsListenerProvider.cs
@@ -9,7 +9,7 @@ public interface INewsListenerProvider
 {
     IReadOnlyCollection<INewsProvider> Providers { get; }
     Task<ICollection<INewsData>> GetNews(int count = 20);
-    Task RefreshAsync(long nubmer = 0);
+    Task RefreshAsync(long count = 0);
     Task AddListener(INewsProvider newsProvider);
     Task RemoveListener(INewsProvider newsProvider);
     Task Restore();

--- a/src/Gml.Core/Core/Integrations/CustomNewsProvider.cs
+++ b/src/Gml.Core/Core/Integrations/CustomNewsProvider.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Gml.Models.News;
 using GmlCore.Interfaces.Enums;
-using GmlCore.Interfaces.Integrations;
 using GmlCore.Interfaces.News;
 using Newtonsoft.Json;
 
@@ -14,12 +13,10 @@ namespace Gml.Core.Integrations;
 
 public class CustomNewsProvider : BaseNewsProvider
 {
-    private readonly string _url;
-
     public CustomNewsProvider(string url)
     {
         Type = NewsListenerType.Custom;
-        _url = url;
+        Url = url;
     }
 
     public override async Task<IReadOnlyCollection<INewsData>> GetNews(int count = 20)
@@ -28,7 +25,7 @@ public class CustomNewsProvider : BaseNewsProvider
         {
             using var httpClient = new HttpClient();
 
-            var response = await httpClient.GetAsync(_url);
+            var response = await httpClient.GetAsync(Url);
 
             if (!response.IsSuccessStatusCode)
                 return [];
@@ -40,7 +37,7 @@ public class CustomNewsProvider : BaseNewsProvider
             var data = JsonConvert.DeserializeObject<CustomNewsResponse[]>(decoded);
 
             if (data is null)
-                return Array.Empty<INewsData>();
+                return [];
 
             return data.Select(x => new NewsData
             {

--- a/src/Gml.Core/Core/Integrations/NewsListenerProvider.cs
+++ b/src/Gml.Core/Core/Integrations/NewsListenerProvider.cs
@@ -57,7 +57,7 @@ public class NewsListenerProvider : INewsListenerProvider, IDisposable, IAsyncDi
         return Task.FromResult<ICollection<INewsData>>(_newsCache);
     }
 
-    public async Task RefreshAsync(long number = 0)
+    public async Task RefreshAsync(long count = 0)
     {
         try
         {


### PR DESCRIPTION
Renamed variables and parameters for consistency across the codebase (e.g., `_url` to `Url`, and `number` to `count`). Added `Gml.Web.Api.OAuth2` project to the solution. Updated `.gitignore` to include `BugStorage.json`.