### PR TITLE
Make profile properties nullable and handle null scenarios

### DIFF
--- a/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
+++ b/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
@@ -64,12 +64,12 @@ namespace GmlCore.Interfaces.Launcher
         /// <summary>
         /// Base64 encoded icon for the profile.
         /// </summary>
-        string IconBase64 { get; set; }
+        string? IconBase64 { get; set; }
 
         /// <summary>
         /// Key for the background image.
         /// </summary>
-        string BackgroundImageKey { get; set; }
+        string? BackgroundImageKey { get; set; }
 
         /// <summary>
         /// Description of the game profile.

--- a/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -719,11 +719,11 @@ namespace Gml.Core.Helpers.Profiles
                 return;
 
             var iconBase64 = icon is null
-                ? profile.IconBase64
+                ? null
                 : await ConvertStreamToBase64Async(icon);
 
             var backgroundKey = backgroundImage is null
-                ? profile.BackgroundImageKey
+                ? null
                 : await _gmlManager.Files.LoadFile(backgroundImage, "profile-backgrounds");
 
             await UpdateProfile(profile, newProfileName, displayName, iconBase64, backgroundKey, updateDtoDescription,
@@ -741,8 +741,8 @@ namespace Gml.Core.Helpers.Profiles
         }
 
         private async Task UpdateProfile(IGameProfile profile, string newProfileName, string displayName,
-            string newIcon,
-            string backgroundImageKey,
+            string? newIcon,
+            string? backgroundImageKey,
             string newDescription, bool needRenameFolder, DirectoryInfo directory, DirectoryInfo newDirectory,
             bool isEnabled,
             string jvmArguments,


### PR DESCRIPTION
Updated `IconBase64` and `BackgroundImageKey` to be nullable in `IGameProfile` to better reflect optional fields. Adjusted related logic to handle null values, ensuring safer null checks and default handling across profile operations.